### PR TITLE
Ensuring all paths in output are posix-based.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -52,7 +52,8 @@ const createViewBasePath = (manifest) => {
 const writeExtensionConfiguration = (manifest, prevManifest) => {
   if (manifest.configuration && !prevManifest.configuration) {
     const viewSrcPath = delegatesMeta.extensionConfiguration.viewTemplatePath;
-    const viewDestPath = path.join(cwd, manifest.viewBasePath, manifest.configuration.viewPath);
+    const viewDestPath =
+      path.posix.join(cwd, manifest.viewBasePath, manifest.configuration.viewPath);
     copyFile(viewSrcPath, viewDestPath);
   }
 };
@@ -116,12 +117,13 @@ const buildStandardDescriptor = (manifest, delegateMeta) => {
     const descriptor = {
       displayName,
       name,
-      libPath: path.join(LIB_PATH, delegateMeta.manifestNodeName, camelCase(name) + '.js'),
+      libPath: path.posix.join(LIB_PATH, delegateMeta.manifestNodeName, camelCase(name) + '.js'),
       schema: require(delegateMeta.schemaTemplatePath)
     };
 
     if (needsView) {
-      descriptor.viewPath = path.join(delegateMeta.manifestNodeName, camelCase(name) + '.html');
+      descriptor.viewPath =
+        path.posix.join(delegateMeta.manifestNodeName, camelCase(name) + '.html');
     }
 
     manifest[delegateMeta.manifestNodeName] = manifest[delegateMeta.manifestNodeName] || [];
@@ -155,7 +157,7 @@ const buildSharedModule = (manifest) => {
   ]).then(({ name }) => {
     const descriptor = {
       name,
-      libPath: path.join(LIB_PATH, delegateMeta.manifestNodeName, camelCase(name) + '.js')
+      libPath: path.posix.join(LIB_PATH, delegateMeta.manifestNodeName, camelCase(name) + '.js')
     };
 
     manifest[delegateMeta.manifestNodeName] = manifest[delegateMeta.manifestNodeName] || [];


### PR DESCRIPTION
Paths inside extension.json always have to be posix-based (forward slashes). If we don't make them posix-based, then on Windows it would use a backslash and won't pass our extension.json validation schema.