### PR TITLE
Add support for `edge` extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information about developing an extension for Launch, please visit our 
 ## Usage
 
 Before running the scaffolding tool, you must first have [Node.js](https://nodejs.org/en/) installed on your computer. Your npm version (npm comes bundled with Node.js) will need to be at least 5.2.0. You can check the installed version by running the following command from a command line:
-                                                                                                      
+
 ```
 npm -v
 ```

--- a/bin/delegateMeta.js
+++ b/bin/delegateMeta.js
@@ -39,6 +39,7 @@ module.exports = {
     libTemplatePath: path.join(__dirname, '../templates/condition.js'),
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/conditionSchema.json'),
+      server: path.join(__dirname, '../templates/conditionSchema.json'),
       mobile: path.join(__dirname, '../templates/mobileConditionSchema.json')
     }
   },
@@ -50,6 +51,7 @@ module.exports = {
     libTemplatePath: path.join(__dirname, '../templates/action.js'),
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/actionSchema.json'),
+      server: path.join(__dirname, '../templates/actionSchema.json'),
       mobile: path.join(__dirname, '../templates/mobileActionSchema.json')
     }
   },
@@ -61,6 +63,7 @@ module.exports = {
     libTemplatePath: path.join(__dirname, '../templates/dataElement.js'),
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/dataElementSchema.json'),
+      server: path.join(__dirname, '../templates/dataElementSchema.json'),
       mobile: path.join(__dirname, '../templates/mobileDataElementSchema.json')
     }
   },

--- a/bin/delegateMeta.js
+++ b/bin/delegateMeta.js
@@ -39,7 +39,7 @@ module.exports = {
     libTemplatePath: path.join(__dirname, '../templates/condition.js'),
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/conditionSchema.json'),
-      server: path.join(__dirname, '../templates/conditionSchema.json'),
+      edge: path.join(__dirname, '../templates/conditionSchema.json'),
       mobile: path.join(__dirname, '../templates/mobileConditionSchema.json')
     }
   },
@@ -51,7 +51,7 @@ module.exports = {
     libTemplatePath: path.join(__dirname, '../templates/action.js'),
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/actionSchema.json'),
-      server: path.join(__dirname, '../templates/actionSchema.json'),
+      edge: path.join(__dirname, '../templates/actionSchema.json'),
       mobile: path.join(__dirname, '../templates/mobileActionSchema.json')
     }
   },
@@ -63,7 +63,7 @@ module.exports = {
     libTemplatePath: path.join(__dirname, '../templates/dataElement.js'),
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/dataElementSchema.json'),
-      server: path.join(__dirname, '../templates/dataElementSchema.json'),
+      edge: path.join(__dirname, '../templates/dataElementSchema.json'),
       mobile: path.join(__dirname, '../templates/mobileDataElementSchema.json')
     }
   },

--- a/bin/index.js
+++ b/bin/index.js
@@ -51,7 +51,7 @@ const copyFile = (fromPath, toPath) => {
   }
 };
 
-const createViewBasePath = manifest => {
+const createViewBasePath = (manifest) => {
   fs.mkdirsSync(manifest.viewBasePath);
 };
 
@@ -74,15 +74,15 @@ const writeStandardDelegates = (manifest, prevManifest, delegateMeta) => {
     const viewSrcPath = delegateMeta.viewTemplatePath;
 
     manifest[nodeName]
-      .filter(descriptor => {
+      .filter((descriptor) => {
         return (
           !prevManifest[nodeName] ||
           !prevManifest[nodeName].some(
-            prevDescriptor => prevDescriptor.name === descriptor.name
+            (prevDescriptor) => prevDescriptor.name === descriptor.name
           )
         );
       })
-      .forEach(descriptor => {
+      .forEach((descriptor) => {
         if (descriptor.viewPath) {
           const viewDestPath = path.join(
             cwd,
@@ -94,7 +94,7 @@ const writeStandardDelegates = (manifest, prevManifest, delegateMeta) => {
 
         // Web extensions should always have this, but just in case
         if (
-          (manifest.platform === 'web' || manifest.platform === 'server') &&
+          (manifest.platform === 'web' || manifest.platform === 'edge') &&
           descriptor.libPath
         ) {
           const libSrcPath = delegateMeta.libTemplatePath;
@@ -120,14 +120,14 @@ const writeManifest = (manifest, prevManifest) => {
   fs.writeJsonSync(path.join(cwd, 'extension.json'), manifest);
 };
 
-const buildConfigurationDescriptor = manifest => {
+const buildConfigurationDescriptor = (manifest) => {
   manifest.configuration = {
     viewPath: 'configuration/configuration.html',
     schema: require(delegatesMeta.extensionConfiguration.schemaTemplatePath),
   };
 };
 
-const addExchangeUrl = manifest => {
+const addExchangeUrl = (manifest) => {
   return inquirer
     .prompt([
       {
@@ -162,7 +162,7 @@ const addExchangeUrl = manifest => {
     });
 };
 
-const addIconPath = manifest => {
+const addIconPath = (manifest) => {
   return inquirer
     .prompt([
       {
@@ -207,11 +207,11 @@ const addIconPath = manifest => {
 
 const buildStandardDescriptor = (manifest, delegateMeta) => {
   const invalidNames = (manifest[delegateMeta.manifestNodeName] || []).map(
-    existingDescriptor => existingDescriptor.name
+    (existingDescriptor) => existingDescriptor.name
   );
 
   const questions = [getDisplayNamePrompt(delegateMeta.nameSingular)];
-  if (manifest.platform === 'web' || manifest.platform === 'server') {
+  if (manifest.platform === 'web' || manifest.platform === 'edge') {
     questions.push(getViewPrompt(delegateMeta.nameSingular));
   }
 
@@ -225,7 +225,7 @@ const buildStandardDescriptor = (manifest, delegateMeta) => {
         schema: require(delegateMeta.schemaTemplatePath[manifest.platform]),
       };
 
-      if (manifest.platform === 'web' || manifest.platform === 'server') {
+      if (manifest.platform === 'web' || manifest.platform === 'edge') {
         descriptor.libPath = path.posix.join(
           LIB_PATH,
           delegateMeta.manifestNodeName,
@@ -246,10 +246,10 @@ const buildStandardDescriptor = (manifest, delegateMeta) => {
     });
 };
 
-const buildSharedModule = manifest => {
+const buildSharedModule = (manifest) => {
   const delegateMeta = delegatesMeta.sharedModule;
   const invalidNames = (manifest[delegateMeta.manifestNodeName] || []).map(
-    existingDescriptor => existingDescriptor.name
+    (existingDescriptor) => existingDescriptor.name
   );
 
   return inquirer
@@ -289,7 +289,7 @@ const buildSharedModule = manifest => {
     });
 };
 
-const buildMavenRepository = answers => {
+const buildMavenRepository = (answers) => {
   return inquirer
     .prompt([
       {
@@ -335,7 +335,7 @@ const buildMavenRepository = answers => {
         },
       },
     ])
-    .then(repositoryAnswers => {
+    .then((repositoryAnswers) => {
       answers.repositories = [
         {
           ...repositoryAnswers,
@@ -346,7 +346,7 @@ const buildMavenRepository = answers => {
     });
 };
 
-const buildCocoapodRepository = answers => {
+const buildCocoapodRepository = (answers) => {
   return inquirer
     .prompt([
       {
@@ -417,7 +417,7 @@ const buildCocoapodRepository = answers => {
         },
       },
     ])
-    .then(repositoryAnswers => {
+    .then((repositoryAnswers) => {
       answers.repositories.push({
         ...repositoryAnswers,
       });
@@ -426,7 +426,7 @@ const buildCocoapodRepository = answers => {
     });
 };
 
-const promptMainMenu = manifest => {
+const promptMainMenu = (manifest) => {
   const choices = [];
 
   if (!manifest.configuration) {
@@ -436,7 +436,7 @@ const promptMainMenu = manifest => {
     });
   }
 
-  if (manifest.platform !== 'server') {
+  if (manifest.platform !== 'edge') {
     choices.push({
       name: 'Add an event type',
       value: buildStandardDescriptor.bind(this, manifest, delegatesMeta.event),
@@ -466,7 +466,7 @@ const promptMainMenu = manifest => {
     }
   );
 
-  if (manifest.platform === 'web' || manifest.platform === 'server') {
+  if (manifest.platform === 'web') {
     choices.push({
       name: 'Add a shared module',
       value: buildSharedModule,
@@ -474,7 +474,7 @@ const promptMainMenu = manifest => {
   }
 
   if (
-    (manifest.platform === 'web' || manifest.platform === 'server') &&
+    (manifest.platform === 'web' || manifest.platform === 'edge') &&
     !manifest.exchangeUrl
   ) {
     choices.push({
@@ -508,15 +508,15 @@ const promptMainMenu = manifest => {
       message: 'What would you like to do?',
       choices,
     })
-    .then(answers => answers.execute(manifest))
-    .then(endMainMenu => {
+    .then((answers) => answers.execute(manifest))
+    .then((endMainMenu) => {
       if (!endMainMenu) {
         return promptMainMenu(manifest);
       }
     });
 };
 
-const getDisplayNamePrompt = nameSingular => {
+const getDisplayNamePrompt = (nameSingular) => {
   return {
     type: 'input',
     name: 'displayName',
@@ -560,7 +560,7 @@ const deriveNameFromDisplayName = (displayName, invalidNames = []) => {
   return name;
 };
 
-const getViewPrompt = nameSingular => {
+const getViewPrompt = (nameSingular) => {
   return {
     type: 'confirm',
     name: 'needsView',
@@ -568,7 +568,7 @@ const getViewPrompt = nameSingular => {
   };
 };
 
-const promptTopLevelFields = manifest => {
+const promptTopLevelFields = (manifest) => {
   return inquirer
     .prompt(
       [
@@ -591,7 +591,7 @@ const promptTopLevelFields = manifest => {
           type: 'list',
           name: 'platform',
           message: 'What is the platform of your extension?',
-          choices: ['web', 'mobile', 'server'],
+          choices: ['web', 'mobile', 'edge'],
         },
         {
           type: 'input',
@@ -635,23 +635,23 @@ const promptTopLevelFields = manifest => {
             return true;
           },
         },
-      ].filter(prompt => {
+      ].filter((prompt) => {
         return !manifest.hasOwnProperty(prompt.name);
       })
     )
-    .then(answers => {
+    .then((answers) => {
       if (answers.platform === 'mobile') {
         return buildMavenRepository(answers);
       }
       return answers;
     })
-    .then(answers => {
+    .then((answers) => {
       if (answers.platform === 'mobile') {
         return buildCocoapodRepository(answers);
       }
       return answers;
     })
-    .then(answers => {
+    .then((answers) => {
       if (answers.displayName) {
         manifest.displayName = answers.displayName;
       }
@@ -730,7 +730,7 @@ const main = () => {
           'extension.'
       );
     })
-    .catch(error => {
+    .catch((error) => {
       console.error(error);
     });
 };

--- a/bin/index.js
+++ b/bin/index.js
@@ -18,8 +18,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const camelCase = require('camelcase');
 const webSchema = require('@adobe/reactor-turbine-schemas/schemas/extension-package-web.json');
-const mobileSchema =
-  require('@adobe/reactor-turbine-schemas/schemas/extension-package-mobile.json');
+const mobileSchema = require('@adobe/reactor-turbine-schemas/schemas/extension-package-mobile.json');
 const validate = require('@adobe/reactor-validator');
 const delegatesMeta = require('./delegateMeta');
 const chalk = require('chalk');
@@ -27,11 +26,14 @@ const chalk = require('chalk');
 const cwd = process.cwd();
 const VIEW_PATH = 'src/view/';
 const LIB_PATH = 'src/lib/';
-const EXTENSION_GUIDE_URL = 'https://developer.adobelaunch.com/guides/extensions/';
+const EXTENSION_GUIDE_URL =
+  'https://developer.adobelaunch.com/guides/extensions/';
 
 const readManifest = () => {
   try {
-    return JSON.parse(fs.readFileSync(path.join(cwd, 'extension.json'), {encoding: 'utf8'}));
+    return JSON.parse(
+      fs.readFileSync(path.join(cwd, 'extension.json'), { encoding: 'utf8' })
+    );
   } catch (err) {
     if (err.code === 'ENOENT') {
       return {};
@@ -45,19 +47,22 @@ const copyFile = (fromPath, toPath) => {
   try {
     fs.copySync(fromPath, toPath, { clobber: false });
   } catch (error) {
-    console.log(`Error writing ${toPath}, but this train doesn't stop.`)
+    console.log(`Error writing ${toPath}, but this train doesn't stop.`);
   }
 };
 
-const createViewBasePath = (manifest) => {
+const createViewBasePath = manifest => {
   fs.mkdirsSync(manifest.viewBasePath);
 };
 
 const writeExtensionConfiguration = (manifest, prevManifest) => {
   if (manifest.configuration && !prevManifest.configuration) {
     const viewSrcPath = delegatesMeta.extensionConfiguration.viewTemplatePath;
-    const viewDestPath =
-      path.posix.join(cwd, manifest.viewBasePath, manifest.configuration.viewPath);
+    const viewDestPath = path.posix.join(
+      cwd,
+      manifest.viewBasePath,
+      manifest.configuration.viewPath
+    );
     copyFile(viewSrcPath, viewDestPath);
   }
 };
@@ -69,22 +74,34 @@ const writeStandardDelegates = (manifest, prevManifest, delegateMeta) => {
     const viewSrcPath = delegateMeta.viewTemplatePath;
 
     manifest[nodeName]
-    .filter((descriptor) => {
-      return !prevManifest[nodeName] ||
-        !prevManifest[nodeName].some((prevDescriptor) => prevDescriptor.name === descriptor.name);
-    }).forEach((descriptor) => {
-      if (descriptor.viewPath) {
-        const viewDestPath = path.join(cwd, manifest.viewBasePath, descriptor.viewPath);
-        copyFile(viewSrcPath, viewDestPath);
-      }
+      .filter(descriptor => {
+        return (
+          !prevManifest[nodeName] ||
+          !prevManifest[nodeName].some(
+            prevDescriptor => prevDescriptor.name === descriptor.name
+          )
+        );
+      })
+      .forEach(descriptor => {
+        if (descriptor.viewPath) {
+          const viewDestPath = path.join(
+            cwd,
+            manifest.viewBasePath,
+            descriptor.viewPath
+          );
+          copyFile(viewSrcPath, viewDestPath);
+        }
 
-      // Web extensions should always have this, but just in case
-      if (manifest.platform === 'web' && descriptor.libPath) {
-        const libSrcPath = delegateMeta.libTemplatePath;
-        const libDestPath = path.join(cwd, descriptor.libPath);
-        copyFile(libSrcPath, libDestPath);
-      }
-    });
+        // Web extensions should always have this, but just in case
+        if (
+          (manifest.platform === 'web' || manifest.platform === 'server') &&
+          descriptor.libPath
+        ) {
+          const libSrcPath = delegateMeta.libTemplatePath;
+          const libDestPath = path.join(cwd, descriptor.libPath);
+          copyFile(libSrcPath, libDestPath);
+        }
+      });
   }
 };
 
@@ -97,339 +114,414 @@ const writeManifest = (manifest, prevManifest) => {
     delegatesMeta.condition,
     delegatesMeta.action,
     delegatesMeta.dataElement,
-    delegatesMeta.sharedModule
+    delegatesMeta.sharedModule,
   ].forEach(writeStandardDelegates.bind(this, manifest, prevManifest));
 
   fs.writeJsonSync(path.join(cwd, 'extension.json'), manifest);
 };
 
-const buildConfigurationDescriptor = (manifest) => {
+const buildConfigurationDescriptor = manifest => {
   manifest.configuration = {
     viewPath: 'configuration/configuration.html',
-    schema: require(delegatesMeta.extensionConfiguration.schemaTemplatePath)
+    schema: require(delegatesMeta.extensionConfiguration.schemaTemplatePath),
   };
 };
 
-const addExchangeUrl = (manifest) => {
-  return inquirer.prompt([
-    {
-      type: 'input',
-      name: 'exchangeUrl',
-      message: 'Please provide the URL to your extension\'s listing on Adobe Exchange.',
-      validate(input) {
-        if (!input.length) {
-          return 'Required.';
-        }
+const addExchangeUrl = manifest => {
+  return inquirer
+    .prompt([
+      {
+        type: 'input',
+        name: 'exchangeUrl',
+        message:
+          "Please provide the URL to your extension's listing on Adobe Exchange.",
+        validate(input) {
+          if (!input.length) {
+            return 'Required.';
+          }
 
-        if (
-          !input.match(
-            /^https:\/\/www\.adobeexchange\.com\/experiencecloud\.details\..+\.html$/gi
-          )
-        ) {
-          return (
-            'Must match the pattern ' +
-            '"https://www.adobeexchange.com/experiencecloud.details.######.html".'
+          if (
+            !input.match(
+              /^https:\/\/www\.adobeexchange\.com\/experiencecloud\.details\..+\.html$/gi
+            )
+          ) {
+            return (
+              'Must match the pattern ' +
+              '"https://www.adobeexchange.com/experiencecloud.details.######.html".'
+            );
+          }
+
+          return true;
+        },
+      },
+    ])
+    .then(({ exchangeUrl }) => {
+      if (exchangeUrl) {
+        manifest.exchangeUrl = exchangeUrl;
+      }
+    });
+};
+
+const addIconPath = manifest => {
+  return inquirer
+    .prompt([
+      {
+        type: 'input',
+        name: 'iconPath',
+        message:
+          'The relative path to the icon that will be displayed for the extension within ' +
+          'Launch. It should not not begin with a slash. It must reference an SVG file with a .svg ' +
+          'extension. The SVG should be square and may be scaled by Launch.',
+        validate(input) {
+          if (!input.length) {
+            return 'Required.';
+          }
+
+          if (!input.match(/^(?!\/).+$/gi)) {
+            return 'Must not start with a "/".';
+          }
+
+          if (!input.match(/\.svg$/gi)) {
+            return 'The icon must have a .svg extension.';
+          }
+
+          return true;
+        },
+      },
+    ])
+    .then(({ iconPath }) => {
+      if (iconPath) {
+        const iconPathOnDisk = path.join(cwd, iconPath);
+        if (!fs.existsSync(iconPathOnDisk)) {
+          console.log(
+            chalk.yellow(
+              `Please don't forget to add an icon at the following location: "${iconPathOnDisk}".`
+            )
           );
         }
 
-        return true;
+        manifest.iconPath = iconPath;
       }
-    }
-  ]).then(({ exchangeUrl }) => {
-    if (exchangeUrl) {
-      manifest.exchangeUrl = exchangeUrl;
-    }
-  });
-};
-
-const addIconPath = (manifest) => {
-  return inquirer.prompt([
-    {
-      type: 'input',
-      name: 'iconPath',
-      message: 'The relative path to the icon that will be displayed for the extension within ' +
-        'Launch. It should not not begin with a slash. It must reference an SVG file with a .svg ' +
-        'extension. The SVG should be square and may be scaled by Launch.',
-      validate(input) {
-        if (!input.length) {
-          return 'Required.';
-        }
-
-        if (!input.match(/^(?!\/).+$/gi)) {
-          return 'Must not start with a "/".';
-        }
-
-        if (!input.match(/\.svg$/gi)) {
-          return 'The icon must have a .svg extension.';
-        }
-
-        return true;
-      }
-    }
-  ]).then(({ iconPath }) => {
-    if (iconPath) {
-      const iconPathOnDisk = path.join(cwd, iconPath);
-      if (!fs.existsSync(iconPathOnDisk)) {
-        console.log(
-          chalk.yellow(
-            `Please don't forget to add an icon at the following location: "${iconPathOnDisk}".`
-          )
-        );
-      }
-
-      manifest.iconPath = iconPath;
-    }
-  });
+    });
 };
 
 const buildStandardDescriptor = (manifest, delegateMeta) => {
-  const invalidNames = (manifest[delegateMeta.manifestNodeName] || [])
-    .map((existingDescriptor) => existingDescriptor.name);
+  const invalidNames = (manifest[delegateMeta.manifestNodeName] || []).map(
+    existingDescriptor => existingDescriptor.name
+  );
 
-  const questions = [
-    getDisplayNamePrompt(delegateMeta.nameSingular),
-  ];
-  if (manifest.platform === 'web') {
+  const questions = [getDisplayNamePrompt(delegateMeta.nameSingular)];
+  if (manifest.platform === 'web' || manifest.platform === 'server') {
     questions.push(getViewPrompt(delegateMeta.nameSingular));
   }
 
-  return inquirer.prompt(questions).then(({ displayName, needsView = true }) => {
-    const name = deriveNameFromDisplayName(displayName, invalidNames);
-    const descriptor = {
-      displayName,
-      name,
-      schema: require(delegateMeta.schemaTemplatePath[manifest.platform])
-    };
+  return inquirer
+    .prompt(questions)
+    .then(({ displayName, needsView = true }) => {
+      const name = deriveNameFromDisplayName(displayName, invalidNames);
+      const descriptor = {
+        displayName,
+        name,
+        schema: require(delegateMeta.schemaTemplatePath[manifest.platform]),
+      };
 
-    if (manifest.platform === 'web') {
-      descriptor.libPath =
-        path.posix.join(LIB_PATH, delegateMeta.manifestNodeName, camelCase(name) + '.js');
-    }
-
-    if (needsView) {
-      descriptor.viewPath =
-        path.posix.join(delegateMeta.manifestNodeName, camelCase(name) + '.html');
-    }
-
-    manifest[delegateMeta.manifestNodeName] = manifest[delegateMeta.manifestNodeName] || [];
-    manifest[delegateMeta.manifestNodeName].push(descriptor);
-  });
-};
-
-const buildSharedModule = (manifest) => {
-  const delegateMeta = delegatesMeta.sharedModule;
-  const invalidNames = (manifest[delegateMeta.manifestNodeName] || [])
-    .map((existingDescriptor) => existingDescriptor.name);
-
-  return inquirer.prompt([
-    {
-      type: 'input',
-      name: 'name',
-      message: 'What is the name of the shared module? Other extensions will access the ' +
-        'shared module by this name. It must consist of lowercase, URL-safe characters.',
-      validate(input) {
-        if (invalidNames.indexOf(input) !== -1) {
-          return input + ' is already being used.';
-        }
-
-        if (!new RegExp(webSchema.definitions.name.pattern).test(input)) {
-          return 'Required. Must consist of lowercase, URL-safe characters.'
-        }
-
-        return true;
-      }
-    }
-  ]).then(({ name }) => {
-    const descriptor = {
-      name,
-      libPath: path.posix.join(LIB_PATH, delegateMeta.manifestNodeName, camelCase(name) + '.js')
-    };
-
-    manifest[delegateMeta.manifestNodeName] = manifest[delegateMeta.manifestNodeName] || [];
-    manifest[delegateMeta.manifestNodeName].push(descriptor);
-  });
-};
-
-const buildMavenRepository = (answers) => {
-  return inquirer.prompt([{
-    type: 'input',
-    name: 'className',
-    default: 'com.mycompany.myExtension',
-    message: 'For Android, what is the fully qualified Java class name of your extension? This is how Android ' +
-      'developers will import your extension in their application.',
-    validate(input) {
-      if (!new RegExp(mobileSchema.definitions.javaClassName.pattern).test(input)) {
-        return 'Required. Must be a valid fully qualified Java class name that contains word ' +
-          'characters, underscores, and dots.'
+      if (manifest.platform === 'web' || manifest.platform === 'server') {
+        descriptor.libPath = path.posix.join(
+          LIB_PATH,
+          delegateMeta.manifestNodeName,
+          camelCase(name) + '.js'
+        );
       }
 
-      return true;
-    }
-  },{
-    type: 'input',
-    name: 'artifact',
-    default: 'com.mycompany.myextension:my-extension:1.0.0',
-    message: 'For Android, we use Maven for dependency management. What is the fully qualified artifact name? ' +
-      'This is in the form of <groupId>:<artifactId>:<version> You can choose whatever name you want with ' +
-      'lowercase letters and no strange symbols.',
-    validate(input) {
-      if (!new RegExp(mobileSchema.definitions.mavenFQArtifactName.pattern).test(input)) {
-        return 'Required. Must be in the form of <groupId>:<artifactId>:<version>'
+      if (needsView) {
+        descriptor.viewPath = path.posix.join(
+          delegateMeta.manifestNodeName,
+          camelCase(name) + '.html'
+        );
       }
 
-      return true;
-    }
-  }]).then(repositoryAnswers => {
-    answers.repositories = [{
-      ...repositoryAnswers
-    }];
-
-    return answers;
-  });
-};
-
-const buildCocoapodRepository = (answers) => {
-  return inquirer.prompt([{
-    type: 'input',
-    name: 'name',
-    default: 'myPod',
-    message: 'For iOS, we use Cocoapods for dependency management. What is the name of the pod?',
-    validate(input) {
-      if (!input.length) {
-          return 'Required. Must consist of word characters or dots.'
-        }
-
-      return true;
-    }
-  },{
-    type: 'input',
-    name: 'headerName',
-    default: 'MyExtension/MyExtension.h',
-    message: 'For iOS, what is the header name? This is how iOS developers will include your framework. ' +
-      'This is in the form of Framework_name/Header_filename.h',
-    validate(input) {
-      if (!new RegExp(mobileSchema.definitions.iosHeaderName.pattern)
-        .test(input)) {
-          return 'Required. Must have a framework name and a header file'
-        }
-
-      return true;
-    }
-  },{
-    type: 'input',
-    name: 'interface',
-    default: 'MyExtension',
-    message: 'For iOS, what is the name of your extension interface? This is how iOS developers will ' +
-      'register your extension',
-    validate(input) {
-      if (!new RegExp(mobileSchema.definitions.iosInterface.pattern)
-        .test(input)) {
-          return 'Required. Must be a valid identifier.'
-        }
-
-      return true;
-    }
-  },{
-    type: 'input',
-    name: 'version',
-    message: 'For iOS, what is the pod version?',
-    default: '1.0.0',
-    validate(input) {
-      if (!new RegExp(mobileSchema.definitions.podVersion.pattern).test(input)) {
-        return 'Required. Must match semantic versioning rules.';
-      }
-
-      return true;
-    }
-  }]).then(repositoryAnswers => {
-    answers.repositories.push({
-      ...repositoryAnswers
+      manifest[delegateMeta.manifestNodeName] =
+        manifest[delegateMeta.manifestNodeName] || [];
+      manifest[delegateMeta.manifestNodeName].push(descriptor);
     });
-
-    return answers;
-  });
 };
 
-const promptMainMenu = (manifest) => {
+const buildSharedModule = manifest => {
+  const delegateMeta = delegatesMeta.sharedModule;
+  const invalidNames = (manifest[delegateMeta.manifestNodeName] || []).map(
+    existingDescriptor => existingDescriptor.name
+  );
+
+  return inquirer
+    .prompt([
+      {
+        type: 'input',
+        name: 'name',
+        message:
+          'What is the name of the shared module? Other extensions will access the ' +
+          'shared module by this name. It must consist of lowercase, URL-safe characters.',
+        validate(input) {
+          if (invalidNames.indexOf(input) !== -1) {
+            return input + ' is already being used.';
+          }
+
+          if (!new RegExp(webSchema.definitions.name.pattern).test(input)) {
+            return 'Required. Must consist of lowercase, URL-safe characters.';
+          }
+
+          return true;
+        },
+      },
+    ])
+    .then(({ name }) => {
+      const descriptor = {
+        name,
+        libPath: path.posix.join(
+          LIB_PATH,
+          delegateMeta.manifestNodeName,
+          camelCase(name) + '.js'
+        ),
+      };
+
+      manifest[delegateMeta.manifestNodeName] =
+        manifest[delegateMeta.manifestNodeName] || [];
+      manifest[delegateMeta.manifestNodeName].push(descriptor);
+    });
+};
+
+const buildMavenRepository = answers => {
+  return inquirer
+    .prompt([
+      {
+        type: 'input',
+        name: 'className',
+        default: 'com.mycompany.myExtension',
+        message:
+          'For Android, what is the fully qualified Java class name of your extension? This is how Android ' +
+          'developers will import your extension in their application.',
+        validate(input) {
+          if (
+            !new RegExp(mobileSchema.definitions.javaClassName.pattern).test(
+              input
+            )
+          ) {
+            return (
+              'Required. Must be a valid fully qualified Java class name that contains word ' +
+              'characters, underscores, and dots.'
+            );
+          }
+
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'artifact',
+        default: 'com.mycompany.myextension:my-extension:1.0.0',
+        message:
+          'For Android, we use Maven for dependency management. What is the fully qualified artifact name? ' +
+          'This is in the form of <groupId>:<artifactId>:<version> You can choose whatever name you want with ' +
+          'lowercase letters and no strange symbols.',
+        validate(input) {
+          if (
+            !new RegExp(
+              mobileSchema.definitions.mavenFQArtifactName.pattern
+            ).test(input)
+          ) {
+            return 'Required. Must be in the form of <groupId>:<artifactId>:<version>';
+          }
+
+          return true;
+        },
+      },
+    ])
+    .then(repositoryAnswers => {
+      answers.repositories = [
+        {
+          ...repositoryAnswers,
+        },
+      ];
+
+      return answers;
+    });
+};
+
+const buildCocoapodRepository = answers => {
+  return inquirer
+    .prompt([
+      {
+        type: 'input',
+        name: 'name',
+        default: 'myPod',
+        message:
+          'For iOS, we use Cocoapods for dependency management. What is the name of the pod?',
+        validate(input) {
+          if (!input.length) {
+            return 'Required. Must consist of word characters or dots.';
+          }
+
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'headerName',
+        default: 'MyExtension/MyExtension.h',
+        message:
+          'For iOS, what is the header name? This is how iOS developers will include your framework. ' +
+          'This is in the form of Framework_name/Header_filename.h',
+        validate(input) {
+          if (
+            !new RegExp(mobileSchema.definitions.iosHeaderName.pattern).test(
+              input
+            )
+          ) {
+            return 'Required. Must have a framework name and a header file';
+          }
+
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'interface',
+        default: 'MyExtension',
+        message:
+          'For iOS, what is the name of your extension interface? This is how iOS developers will ' +
+          'register your extension',
+        validate(input) {
+          if (
+            !new RegExp(mobileSchema.definitions.iosInterface.pattern).test(
+              input
+            )
+          ) {
+            return 'Required. Must be a valid identifier.';
+          }
+
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'version',
+        message: 'For iOS, what is the pod version?',
+        default: '1.0.0',
+        validate(input) {
+          if (
+            !new RegExp(mobileSchema.definitions.podVersion.pattern).test(input)
+          ) {
+            return 'Required. Must match semantic versioning rules.';
+          }
+
+          return true;
+        },
+      },
+    ])
+    .then(repositoryAnswers => {
+      answers.repositories.push({
+        ...repositoryAnswers,
+      });
+
+      return answers;
+    });
+};
+
+const promptMainMenu = manifest => {
   const choices = [];
 
   if (!manifest.configuration) {
     choices.push({
       name: 'Add an extension configuration view',
-      value: buildConfigurationDescriptor
+      value: buildConfigurationDescriptor,
+    });
+  }
+
+  if (manifest.platform !== 'server') {
+    choices.push({
+      name: 'Add an event type',
+      value: buildStandardDescriptor.bind(this, manifest, delegatesMeta.event),
     });
   }
 
   choices.push(
     {
-      name: 'Add an event type',
-      value: buildStandardDescriptor.bind(this, manifest, delegatesMeta.event)
-    },
-    {
       name: 'Add a condition type',
-      value: buildStandardDescriptor.bind(this, manifest, delegatesMeta.condition)
+      value: buildStandardDescriptor.bind(
+        this,
+        manifest,
+        delegatesMeta.condition
+      ),
     },
     {
       name: 'Add an action type',
-      value: buildStandardDescriptor.bind(this, manifest, delegatesMeta.action)
+      value: buildStandardDescriptor.bind(this, manifest, delegatesMeta.action),
     },
     {
       name: 'Add a data element type',
-      value: buildStandardDescriptor.bind(this, manifest, delegatesMeta.dataElement)
+      value: buildStandardDescriptor.bind(
+        this,
+        manifest,
+        delegatesMeta.dataElement
+      ),
     }
   );
 
-  if (manifest.platform === 'web') {
+  if (manifest.platform === 'web' || manifest.platform === 'server') {
     choices.push({
       name: 'Add a shared module',
-      value: buildSharedModule
+      value: buildSharedModule,
     });
   }
 
-  if (manifest.platform === 'web' && !manifest.exchangeUrl) {
+  if (
+    (manifest.platform === 'web' || manifest.platform === 'server') &&
+    !manifest.exchangeUrl
+  ) {
     choices.push({
       name: 'Add an Exchange URL',
-      value: addExchangeUrl
+      value: addExchangeUrl,
     });
   }
 
   if (!manifest.iconPath) {
     choices.push({
       name: 'Add an icon path',
-      value: addIconPath
+      value: addIconPath,
     });
   }
 
   choices.push(
     new inquirer.Separator(),
     {
-      name: 'I\'m done.',
+      name: "I'm done.",
       value: () => {
         return Promise.resolve(true);
-      }
+      },
     },
     new inquirer.Separator()
   );
 
-  return inquirer.prompt({
-    type: 'list',
-    name: 'execute',
-    message: 'What would you like to do?',
-    choices
-  })
-  .then((answers) => answers.execute(manifest))
-  .then((endMainMenu) => {
-    if (!endMainMenu) {
-      return promptMainMenu(manifest);
-    }
-  });
+  return inquirer
+    .prompt({
+      type: 'list',
+      name: 'execute',
+      message: 'What would you like to do?',
+      choices,
+    })
+    .then(answers => answers.execute(manifest))
+    .then(endMainMenu => {
+      if (!endMainMenu) {
+        return promptMainMenu(manifest);
+      }
+    });
 };
 
-const getDisplayNamePrompt = (nameSingular) => {
+const getDisplayNamePrompt = nameSingular => {
   return {
     type: 'input',
     name: 'displayName',
-    message: `What is the display name of the ${nameSingular}? ` +
+    message:
+      `What is the display name of the ${nameSingular}? ` +
       `This will be shown to users of Launch.`,
     validate(input) {
       if (!input.length) {
@@ -437,7 +529,7 @@ const getDisplayNamePrompt = (nameSingular) => {
       }
 
       return true;
-    }
+    },
   };
 };
 
@@ -465,144 +557,157 @@ const deriveNameFromDisplayName = (displayName, invalidNames = []) => {
     suffixIncrementor++;
   } while (invalidNames.indexOf(name) !== -1);
 
-  return name
+  return name;
 };
 
-const getViewPrompt = (nameSingular) => {
+const getViewPrompt = nameSingular => {
   return {
     type: 'confirm',
     name: 'needsView',
-    message: `Does this ${nameSingular} need a view for accepting settings from a user?`
-  }
+    message: `Does this ${nameSingular} need a view for accepting settings from a user?`,
+  };
 };
 
-const promptTopLevelFields = (manifest) => {
-  return inquirer.prompt([
-    {
-      type: 'input',
-      name: 'displayName',
-      message: 'What is the display name of your extension? ' +
-      'This will be shown to users of Launch. There is no need to mention ' +
-      '"Launch" or "Extension"; users will already know they are looking at a Launch extension.',
-      validate(input) {
-        if (!input.length) {
-          return 'Required.';
-        }
+const promptTopLevelFields = manifest => {
+  return inquirer
+    .prompt(
+      [
+        {
+          type: 'input',
+          name: 'displayName',
+          message:
+            'What is the display name of your extension? ' +
+            'This will be shown to users of Launch. There is no need to mention ' +
+            '"Launch" or "Extension"; users will already know they are looking at a Launch extension.',
+          validate(input) {
+            if (!input.length) {
+              return 'Required.';
+            }
 
-        return true;
+            return true;
+          },
+        },
+        {
+          type: 'list',
+          name: 'platform',
+          message: 'What is the platform of your extension?',
+          choices: ['web', 'mobile', 'server'],
+        },
+        {
+          type: 'input',
+          name: 'version',
+          message: 'What version would you like to start with?',
+          default: '1.0.0',
+          validate(input) {
+            if (!new RegExp(webSchema.definitions.semver.pattern).test(input)) {
+              return 'Required. Must match semantic versioning rules.';
+            }
+
+            return true;
+          },
+        },
+        {
+          type: 'input',
+          name: 'description',
+          message:
+            'Please provide a short description of your extension. This will be shown to ' +
+            'users of Launch. If your extension empowers users to implement your product on their ' +
+            'website, describe what your product does. There is no need to mention "Launch" or ' +
+            '"Extension"; users will already know they are looking at a Launch extension.',
+          validate(input) {
+            if (!input.length) {
+              return 'Required.';
+            }
+
+            return true;
+          },
+        },
+        {
+          type: 'input',
+          name: 'author',
+          message:
+            'Who is the author? This can be the name of an individual, company, or group.',
+          validate(input) {
+            if (!input.length) {
+              return 'Required.';
+            }
+
+            return true;
+          },
+        },
+      ].filter(prompt => {
+        return !manifest.hasOwnProperty(prompt.name);
+      })
+    )
+    .then(answers => {
+      if (answers.platform === 'mobile') {
+        return buildMavenRepository(answers);
       }
-    },
-    {
-      type: 'list',
-      name: 'platform',
-      message: 'What is the platform of your extension?',
-      choices: ['web', 'mobile']
-    },
-    {
-      type: 'input',
-      name: 'version',
-      message: 'What version would you like to start with?',
-      default: '1.0.0',
-      validate(input) {
-        if (!new RegExp(webSchema.definitions.semver.pattern).test(input)) {
-          return 'Required. Must match semantic versioning rules.';
-        }
-
-        return true;
+      return answers;
+    })
+    .then(answers => {
+      if (answers.platform === 'mobile') {
+        return buildCocoapodRepository(answers);
       }
-    },
-    {
-      type: 'input',
-      name: 'description',
-      message: 'Please provide a short description of your extension. This will be shown to ' +
-      'users of Launch. If your extension empowers users to implement your product on their ' +
-      'website, describe what your product does. There is no need to mention "Launch" or ' +
-      '"Extension"; users will already know they are looking at a Launch extension.',
-      validate(input) {
-        if (!input.length) {
-          return 'Required.';
-        }
-
-        return true;
+      return answers;
+    })
+    .then(answers => {
+      if (answers.displayName) {
+        manifest.displayName = answers.displayName;
       }
-    },
-    {
-      type: 'input',
-      name: 'author',
-      message: 'Who is the author? This can be the name of an individual, company, or group.',
-      validate(input) {
-        if (!input.length) {
-          return 'Required.';
-        }
 
-        return true;
+      if (!manifest.name) {
+        manifest.name = deriveNameFromDisplayName(manifest.displayName);
       }
-    }
-  ].filter((prompt) => {
-    return !manifest.hasOwnProperty(prompt.name);
-  })).then((answers) => {
-    if (answers.platform === 'mobile') {
-      return buildMavenRepository(answers);
-    }
-    return answers;
-  }).then((answers) => {
-    if (answers.platform === 'mobile') {
-      return buildCocoapodRepository(answers);
-    }
-    return answers;
-  }).then((answers) => {
-    if (answers.displayName) {
-      manifest.displayName = answers.displayName;
-    }
 
-    if (!manifest.name) {
-      manifest.name = deriveNameFromDisplayName(manifest.displayName);
-    }
+      if (answers.platform) {
+        manifest.platform = answers.platform;
+      }
 
-    if (answers.platform) {
-      manifest.platform = answers.platform;
-    }
+      if (answers.version) {
+        manifest.version = answers.version;
+      }
 
-    if (answers.version) {
-      manifest.version = answers.version;
-    }
+      if (answers.description) {
+        manifest.description = answers.description;
+      }
 
-    if (answers.description) {
-      manifest.description = answers.description;
-    }
+      if (answers.author) {
+        manifest.author = {
+          name: answers.author,
+        };
+      }
 
-    if (answers.author) {
-      manifest.author = {
-        name: answers.author
-      };
-    }
+      if (answers.exchangeUrl) {
+        manifest.exchangeUrl = answers.exchangeUrl;
+      }
 
-    if (answers.exchangeUrl) {
-      manifest.exchangeUrl = answers.exchangeUrl;
-    }
+      if (answers.iconPath) {
+        manifest.iconPath = answers.iconPath;
+      }
 
-    if (answers.iconPath) {
-      manifest.iconPath = answers.iconPath;
-    }
+      if (answers.repositories) {
+        manifest.repositories = answers.repositories;
+      }
 
-    if (answers.repositories) {
-      manifest.repositories = answers.repositories;
-    }
-
-    // We could make this configurable, but then do we make where library files go configurable
-    // as well? Then we would have to pass the library base path around separately since it's not a
-    // direct property of the manifest like viewBasePath is.
-    manifest.viewBasePath = manifest.viewBasePath || VIEW_PATH;
-  });
+      // We could make this configurable, but then do we make where library files go configurable
+      // as well? Then we would have to pass the library base path around separately since it's not a
+      // direct property of the manifest like viewBasePath is.
+      manifest.viewBasePath = manifest.viewBasePath || VIEW_PATH;
+    });
 };
 
 const main = () => {
   const manifest = readManifest();
   const prevManifest = clone(manifest);
 
-  console.log('Welcome to the scaffolding tool. Let\'s build the foundational structure for ' +
-    'your extension. To learn more about the components of an extension, please reference the ' +
-    'extension development guide at ' + EXTENSION_GUIDE_URL + '.');
+  console.log(
+    "Welcome to the scaffolding tool. Let's build the foundational structure for " +
+      'your extension. To learn more about the components of an extension, please reference the ' +
+      'extension development guide at ' +
+      EXTENSION_GUIDE_URL +
+      '.'
+  );
 
   promptTopLevelFields(manifest)
     .then(() => promptMainMenu(manifest))
@@ -612,15 +717,20 @@ const main = () => {
       // files exist.
       const error = validate(manifest);
       if (error) {
-        return Promise.reject('Your extension does not pass validation. This could be a bug ' +
-          'with the scaffold tool. Error: ' + error);
+        return Promise.reject(
+          'Your extension does not pass validation. This could be a bug ' +
+            'with the scaffold tool. Error: ' +
+            error
+        );
       }
     })
     .then(() => {
-      console.log('Scaffolding complete. You may run the tool again at any time to add to your ' +
-        'extension.');
+      console.log(
+        'Scaffolding complete. You may run the tool again at any time to add to your ' +
+          'extension.'
+      );
     })
-    .catch((error) => {
+    .catch(error => {
       console.error(error);
     });
 };

--- a/bin/index.js
+++ b/bin/index.js
@@ -142,13 +142,10 @@ const addExchangeUrl = (manifest) => {
 
           if (
             !input.match(
-              /^https:\/\/www\.adobeexchange\.com\/experiencecloud\.details\..+\.html$/gi
+              /^https?:\/\/[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]+\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/gi
             )
           ) {
-            return (
-              'Must match the pattern ' +
-              '"https://www.adobeexchange.com/experiencecloud.details.######.html".'
-            );
+            return 'Must be a URL.';
           }
 
           return true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@adobe/reactor-turbine-schemas": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-8.0.3.tgz",
-      "integrity": "sha512-4OBTKH2GC8hUodPn4LSpXwlQsGDmOAk3FGgGP7n16F0G9/Cj+QDl1pCcwmXLXBkovacBNPvnAowFniYHRoTIEw=="
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-8.5.0.tgz",
+      "integrity": "sha512-je8ogz0Gh7OfJpc4dBdgqB//EBqN+geJXFhmQFOkd0ioFyPGN+nxBBxXxu5SKNK2yLtTL6hiBAciukBq8Rms+A=="
     },
     "@adobe/reactor-validator": {
       "version": "2.0.6",
@@ -218,9 +218,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "mimic-fn": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,105 +5,116 @@
   "requires": true,
   "dependencies": {
     "@adobe/reactor-turbine-schemas": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-8.5.0.tgz",
-      "integrity": "sha512-je8ogz0Gh7OfJpc4dBdgqB//EBqN+geJXFhmQFOkd0ioFyPGN+nxBBxXxu5SKNK2yLtTL6hiBAciukBq8Rms+A=="
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-9.1.3.tgz",
+      "integrity": "sha512-koWPgAbWYG5/WU2C++8a4sUoZ5amwiWD8IxoELUx73TPCE2IR3IdrTSFQ91B9bOhgSa1224DcJSfsm3LMyIMsw=="
     },
     "@adobe/reactor-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@adobe/reactor-validator/-/reactor-validator-2.0.6.tgz",
-      "integrity": "sha512-DR+GnpJfgkbUwaEoj2o7APFCCpGf9CDIq+n25qM7gKuXsncdKQlU2tE4D+5jxzh/c+EjsSJCJ+kFW5xecLn1OQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-validator/-/reactor-validator-2.0.8.tgz",
+      "integrity": "sha512-gKAF+hwTOrxvGB7XdHGTRUIw34yXUX9soFITJVtK0vDc1iAsO8F064MSP7OO1Z3Ol6zONYT23YbBOV+Dtu9pIw==",
       "requires": {
-        "@adobe/reactor-turbine-schemas": "^8.2.0",
-        "ajv": "^6.5.1"
-      },
-      "dependencies": {
-        "@adobe/reactor-turbine-schemas": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-8.2.0.tgz",
-          "integrity": "sha512-hBmzLMhNwrATt3nOT5O8TaMtXARVFtLNfnNdRimMPQq/oyGNHemXrAKXPmyY3idiYpPJU53HlcH+adpEUWQuFA=="
-        }
+        "@adobe/reactor-turbine-schemas": "^9.1.0",
+        "ajv": "^6.12.2"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "ajv": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-    },
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "type-fest": "^0.11.0"
       }
     },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+      "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "chardet": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
-      "integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -111,90 +122,86 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "external-editor": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.0.tgz",
-      "integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "requires": {
-        "chardet": "^0.5.0",
-        "iconv-lite": "^0.4.22",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
     },
     "fs-extra": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "inquirer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.0.0.tgz",
-      "integrity": "sha512-tISQWRwtcAgrz+SHPhTH7d3e73k31gsOy6i1csonLc0u1dVK/wYvuOnFeiWqC5OXFIYbmrIFInef31wbT8MEJg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       }
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -202,42 +209,35 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
       "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "os-tmpdir": {
@@ -251,26 +251,23 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "rxjs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-      "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -281,33 +278,34 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.0"
       }
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "through": {
@@ -324,14 +322,24 @@
       }
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    },
+    "type-fest": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-scaffold",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-scaffold",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-scaffold",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Command line scaffolding tool for building Launch extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-scaffold",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Command line scaffolding tool for building Launch extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "reactor-scaffold": "./bin/index.js"
   },
   "dependencies": {
-    "@adobe/reactor-turbine-schemas": "^8.0.2",
+    "@adobe/reactor-turbine-schemas": "^8.5.0",
     "@adobe/reactor-validator": "^2.0.6",
     "camelcase": "^4.0.0",
     "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "reactor-scaffold": "./bin/index.js"
   },
   "dependencies": {
-    "@adobe/reactor-turbine-schemas": "^8.5.0",
-    "@adobe/reactor-validator": "^2.0.6",
-    "camelcase": "^4.0.0",
-    "chalk": "^2.4.1",
-    "clone": "^2.1.0",
-    "fs-extra": "^1.0.0",
-    "inquirer": "^6.0.0"
+    "@adobe/reactor-turbine-schemas": "^9.1.3",
+    "@adobe/reactor-validator": "^2.0.8",
+    "camelcase": "^6.0.0",
+    "chalk": "^4.1.0",
+    "clone": "^2.1.2",
+    "fs-extra": "^9.0.1",
+    "inquirer": "^7.3.3"
   }
 }


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding support for `edge` extensions. There are very similar to `web` extensions except some differences:
- don't have events
- don't have shared modules
- don't have main module

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

You can preview the changes by running `npx @adobe/reactor-scaffold@2.2.1`. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.