### PR TITLE
PDCL-5747: Fix broken pathways for mobile scaffold files

### DIFF
--- a/bin/delegateMeta.js
+++ b/bin/delegateMeta.js
@@ -20,6 +20,7 @@ module.exports = {
     viewTemplatePath: {
       web: path.join(__dirname, '../templates/configuration.html'),
       edge: path.join(__dirname, '../templates/configuration.html'),
+      mobile: path.join(__dirname, '../templates/configuration.html'),
     },
     schemaTemplatePath: path.join(
       __dirname,
@@ -30,8 +31,14 @@ module.exports = {
     nameSingular: 'event',
     namePlural: 'events',
     manifestNodeName: 'events',
-    viewTemplatePath: { web: path.join(__dirname, '../templates/event.html') },
-    libTemplatePath: { web: path.join(__dirname, '../templates/web/event.js') },
+    viewTemplatePath: {
+      web: path.join(__dirname, '../templates/event.html'),
+      mobile: path.join(__dirname, '../templates/event.html'),
+    },
+    libTemplatePath: {
+      web: path.join(__dirname, '../templates/web/event.js'),
+      mobile: path.join(__dirname, '../templates/mobile/event.js'),
+    },
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/eventSchema.json'),
       mobile: path.join(__dirname, '../templates/mobileEventSchema.json'),
@@ -44,10 +51,12 @@ module.exports = {
     viewTemplatePath: {
       web: path.join(__dirname, '../templates/condition.html'),
       edge: path.join(__dirname, '../templates/condition.html'),
+      mobile: path.join(__dirname, '../templates/condition.html'),
     },
     libTemplatePath: {
       web: path.join(__dirname, '../templates/web/condition.js'),
       edge: path.join(__dirname, '../templates/edge/condition.js'),
+      mobile: path.join(__dirname, '../templates/mobile/condition.js'),
     },
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/conditionSchema.json'),
@@ -62,10 +71,12 @@ module.exports = {
     viewTemplatePath: {
       web: path.join(__dirname, '../templates/action.html'),
       edge: path.join(__dirname, '../templates/action.html'),
+      mobile: path.join(__dirname, '../templates/action.html'),
     },
     libTemplatePath: {
       web: path.join(__dirname, '../templates/web/action.js'),
       edge: path.join(__dirname, '../templates/edge/action.js'),
+      mobile: path.join(__dirname, '../templates/mobile/action.js'),
     },
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/actionSchema.json'),
@@ -80,10 +91,12 @@ module.exports = {
     viewTemplatePath: {
       web: path.join(__dirname, '../templates/dataElement.html'),
       edge: path.join(__dirname, '../templates/dataElement.html'),
+      mobile: path.join(__dirname, '../templates/dataElement.html'),
     },
     libTemplatePath: {
       web: path.join(__dirname, '../templates/web/dataElement.js'),
       edge: path.join(__dirname, '../templates/edge/dataElement.js'),
+      mobile: path.join(__dirname, '../templates/mobile/dataElement.js'),
     },
     schemaTemplatePath: {
       web: path.join(__dirname, '../templates/dataElementSchema.json'),
@@ -97,6 +110,7 @@ module.exports = {
     manifestNodeName: 'sharedModules',
     libTemplatePath: {
       web: path.join(__dirname, '../templates/web/sharedModule.js'),
+      mobile: path.join(__dirname, '../templates/mobile/sharedModule.js'),
     },
   },
 };

--- a/templates/mobile/action.js
+++ b/templates/mobile/action.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(settings) {
+  // TODO Perform some action.
+};

--- a/templates/mobile/condition.js
+++ b/templates/mobile/condition.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(settings) {
+  // TODO Return whether the condition passes.
+};

--- a/templates/mobile/dataElement.js
+++ b/templates/mobile/dataElement.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(settings) {
+  // TODO Return the data element value.
+};

--- a/templates/mobile/event.js
+++ b/templates/mobile/event.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(settings, trigger) {
+  // TODO Start watching for an event. Call trigger when the event occurs.
+};

--- a/templates/mobile/sharedModule.js
+++ b/templates/mobile/sharedModule.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// TODO: Export something that provides value to other extensions.
+module.exports = {};


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the ability to use the scaffold tool to make mobile extensions. Resolves #17 .

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-5747

## Motivation and Context

#15 introduced separated module files for web and edge, but didn't provide those renamed files for mobile.

## How Has This Been Tested?

manual verification of mobile portion.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.